### PR TITLE
Add patch method to update foods with sad path and testing

### DIFF
--- a/routes/api/v1/foods/foods_controller.js
+++ b/routes/api/v1/foods/foods_controller.js
@@ -1,7 +1,7 @@
 var express = require("express");
 var router = express.Router();
 var Food = require('../../../../models').Food;
-var defaultHeader = ["Content-Type", "appication/json"];
+var defaultHeader = ["Content-Type", "application/json"];
 
 /* GET all foods */
 router.get("/", async function(req, res, next) {
@@ -40,6 +40,28 @@ router.post("/", async function (req, res, next) {
     res.status(201).send(JSON.stringify(food, ['id', 'name', 'calories']));
   } catch {
     let error = 'Food Not Created'
+    res.setHeader(...defaultHeader);
+    res.status(400).send({ error })
+  }
+});
+
+router.patch("/:id", async function (req, res, next) {
+  try {
+    let food = await Food.findOne({
+      where: {id: req.params.id }
+    });
+    if (req.body.name && req.body.calories) {
+    food.update({
+      name: req.body.name,
+      calories: req.body.calories
+    })
+    } else {
+      throw "You must give both name and calories"
+    }
+    res.setHeader(...defaultHeader);
+    res.status(201).send(JSON.stringify(food, ['id', 'name', 'calories']));
+  } catch {
+    let error = 'Food Not Updated'
     res.setHeader(...defaultHeader);
     res.status(400).send({ error })
   }

--- a/routes/api/v1/foods/foods_controller.spec.js
+++ b/routes/api/v1/foods/foods_controller.spec.js
@@ -55,11 +55,37 @@ describe('Test GET /api/v1/foods path', () => {
     expect(response.body['calories']).toEqual(300)
   });
 
-  test('receives a 404 if invalid credentials are provided', async () => {
+  test('receives a 400 if invalid credentials are provided when creating food', async () => {
     let response = await request(app).post(`/api/v1/foods`).send({
       food: {
         name: 'foody'
       }
+    })
+    expect(response.status).toBe(400)
+  });
+
+  test('update an existing object with valid credentials', async () => {
+    let response = await request(app).patch(`/api/v1/foods/1`).send({
+      name: 'mango',
+      calories: 350
+    })
+    expect(response.status).toBe(201)
+    expect(response.body['id']).toEqual(1)
+    expect(response.body['name']).toEqual('mango')
+    expect(response.body['calories']).toEqual(350)
+  });
+
+  test('receives a 400 if credentials are missing when updating food', async () => {
+    let response = await request(app).patch(`/api/v1/foods/1`).send({
+      name: 'strawberry'
+    })
+    expect(response.status).toBe(400)
+  });
+
+  test('receives a 400 if given invalid id for updating food', async () => {
+    let response = await request(app).patch(`/api/v1/foods/1000`).send({
+      name: 'blueberry',
+      calories: '700'
     })
     expect(response.status).toBe(400)
   });


### PR DESCRIPTION
Co-Authored-By: null <noah.flint@gmail.com>

# Type of change
- [x] New feature
- [] Bug Fix

# Description of Changes:
- Added a patch router to update existing foods with mandatory name, calories params given with id
- fixed typo of "application/json" in defaultHeader variable

# Tests Written:
- tested for updating object with name and calories
- tested for sad path when only one param is given
- tested for sad path when invalid/non-existing food id is given

# Test Coverage:
- Overall coverage: 93.81%